### PR TITLE
Refactor level loading for smoother frames

### DIFF
--- a/js/Brick.js
+++ b/js/Brick.js
@@ -8,6 +8,7 @@ export class Brick {
     this.vx   = opts.vx ?? 0;   // for moving bricks
     this.vy   = opts.vy ?? 0;
     this.alive = true;
+    this._onRemove = opts.onRemove;
 
     // Visual overrides (optional)
     if (opts.background) this.node.style.background = opts.background;
@@ -45,6 +46,7 @@ export class Brick {
   destroy() {
     if (!this.alive) return;
     this.alive = false;
-    this.node.remove();
+    if (this._onRemove) this._onRemove(this.node);
+    else this.node.remove();
   }
 }

--- a/js/Game.js
+++ b/js/Game.js
@@ -46,6 +46,10 @@ export class Game {
     this._projectiles = [];
     this._boss = null;
 
+    // Brick pooling
+    this._brickPool = [];
+    this._tplBrick = document.getElementById('tpl-brick');
+
     // UI buttons
     this.ui.onRetry(() => this.resetAll());
     this.ui.onExit(()  => this.exitToTitle());
@@ -202,21 +206,20 @@ export class Game {
     this.ball.setSpeedMultiplier(this.script.speedMul ?? 1);
     this.paddle.setSpeedMultiplier(this.script.speedMul ?? 1);
 
-    // Bricks
-    this.layerBricks.innerHTML = '';
-    this.bricks = this.script.createBricks(this);
-    this.grid.build(this.bricks, this.width, this.height);
-    this._gridRebuildCooldown = 0;
-
-    // Auto low-fx for massive brick counts
-    if (this.bricks.length > 240) this.board.classList.add('lowfx');
-    else this.board.classList.remove('lowfx');
-
-    // Ball reset
-    this.ball.resetToPaddle(this.paddle);
-
-    // Level hook
-    this.script.onEnter?.(this);
+    this._clearBricks();
+    const start = performance.now();
+    this._runInFrames([
+      () => { this.bricks = this.script.createBricks(this); },
+      () => {
+        this.grid.build(this.bricks, this.width, this.height);
+        this._gridRebuildCooldown = 0;
+        if (this.bricks.length > 240) this.board.classList.add('lowfx');
+        else this.board.classList.remove('lowfx');
+        this.ball.resetToPaddle(this.paddle);
+        this.script.onEnter?.(this);
+        console.debug(`level ${n} build ${(performance.now()-start).toFixed(2)}ms`);
+      },
+    ]);
   }
 
   resetAll() {
@@ -230,6 +233,7 @@ export class Game {
     this.ui.updateLives(this.lives);
     this.ui.resetTimer();
     this.gameRoot.classList.remove('paused');
+    this._clearBricks();
     this.loadLevel(this.level);
     this.board.focus();
   }
@@ -239,20 +243,67 @@ export class Game {
     this.lives = 3;
     this.ui.updateScore(this.score);
     this.ui.updateLives(this.lives);
-    this.layerBricks.innerHTML = '';
-    this.bricks = this.script.createBricks(this);
-    this.grid.build(this.bricks, this.width, this.height);
-    this.ball.resetToPaddle(this.paddle);
-    this.input.paused = false;
-    this._lifeLock = false;
-    this.ui.resetTimer();
-    this.ui.hidePause();
-    this.gameRoot.classList.remove('paused');
+    this._clearBricks();
+    this._runInFrames([
+      () => { this.bricks = this.script.createBricks(this); },
+      () => {
+        this.grid.build(this.bricks, this.width, this.height);
+        this.ball.resetToPaddle(this.paddle);
+        this.input.paused = false;
+        this._lifeLock = false;
+        this.ui.resetTimer();
+        this.ui.hidePause();
+        this.gameRoot.classList.remove('paused');
+      },
+    ]);
   }
 
   exitToTitle() { window.location.reload(); }
   _continueFromPause() { this.input.paused = false; this.gameRoot.classList.remove('paused'); }
   addScore(v = 10) { this.score += v; }
+
+  // --- Brick pooling helpers ---
+  _acquireBrickNode() {
+    const n = this._brickPool.pop();
+    if (n) {
+      n.removeAttribute('style');
+      return n;
+    }
+    return this._tplBrick.content.firstElementChild.cloneNode(true);
+  }
+
+  _releaseBrickNode(node) {
+    node.remove();
+    node.removeAttribute('style');
+    this._brickPool.push(node);
+  }
+
+  _clearBricks() {
+    for (const b of this.bricks) {
+      if (b.alive) b.destroy();
+    }
+    this.bricks = [];
+  }
+
+  _scheduleIdle(cb) {
+    if ('requestIdleCallback' in window) requestIdleCallback(cb);
+    else requestAnimationFrame(cb);
+  }
+
+  _runInFrames(tasks) {
+    const start = performance.now();
+    const step = () => {
+      const fn = tasks.shift();
+      if (!fn) return;
+      const t0 = performance.now();
+      fn();
+      const t1 = performance.now();
+      console.debug(`stage took ${(t1 - t0).toFixed(2)}ms`);
+      if (tasks.length) this._scheduleIdle(step);
+      else console.debug(`build total ${(t1 - start).toFixed(2)}ms`);
+    };
+    this._scheduleIdle(step);
+  }
 
   // Life loss + small glitch feedback
   loseLife() {

--- a/js/levels/helpers.js
+++ b/js/levels/helpers.js
@@ -12,14 +12,13 @@ export function buildPattern(container, game, rows, cols, shouldPlace, styleAt, 
 
   const bricks = [];
   const frag = document.createDocumentFragment();
-  const tpl = document.getElementById('tpl-brick');
 
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {
       if (!shouldPlace(r, c, rows, cols)) continue;
       const x = c * (bw + gap);
       const y = topPadding + r * (bh + gap);
-      const node = tpl.content.firstElementChild.cloneNode(true);
+      const node = game._acquireBrickNode();
       node.style.width = bw + 'px';
       node.style.height = bh + 'px';
       const bg = styleAt?.(r, c);
@@ -27,6 +26,7 @@ export function buildPattern(container, game, rows, cols, shouldPlace, styleAt, 
       frag.appendChild(node);
 
       const opts = optsAt?.(r, c) ?? {};
+      opts.onRemove = game._releaseBrickNode.bind(game);
       const b = new Brick(node, x, y, bw, bh, opts);
       bricks.push(b);
     }


### PR DESCRIPTION
## Summary
- Split level loading into staged idle callbacks to build bricks and collision grid over multiple frames
- Recycle brick DOM nodes via a pool instead of clearing with innerHTML to cut GC spikes
- Log build stage timings with `performance.now()` to observe steady ~60fps during level resets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cc094d6c83248f1c1ca460b763ba