### PR TITLE
Cap simulation steps per frame and warn on backlog

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -6,16 +6,24 @@ const game = new Game();
 let last = performance.now();
 let acc = 0;
 const STEP = 1000 / 120; // 120 Hz sim step (in ms)
+const MAX_STEPS = 3; // Cap sim steps per frame to avoid huge catch-ups
 
 function loop(now) {
   const frameDt = Math.min(100, now - last);
   last = now;
   acc += frameDt;
 
-  // Run the sim in fixed steps, catch up if needed
-  while (acc >= STEP) {
+  // Run the sim in fixed steps, but cap iterations to avoid long hitches
+  let steps = 0;
+  while (acc >= STEP && steps < MAX_STEPS) {
     game.simulate(STEP);
     acc -= STEP;
+    steps++;
+  }
+  if (acc >= STEP) {
+    const skipped = Math.floor(acc / STEP);
+    console.warn(`Skipping ${skipped} simulation steps to catch up`);
+    acc = 0; // Drop remaining backlog
   }
 
   // Render once per rAF


### PR DESCRIPTION
## Summary
- Cap fixed simulation step iterations per frame to three and warn when backlog is skipped

## Testing
- `npm test` *(fails: enoent package.json)*
- `go test ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cc0ef334832486a51b558386c02d