### PR TITLE
Enable level selection from pause menu and streamline overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,22 +16,6 @@
     <div id="fps" aria-live="off">FPS: --</div>
     <div id="drops" aria-live="off">Drops: 0</div>
 
-    <div id="level-select" class="hud-panel">
-      <label for="levelBtn">Level:</label>
-      <select id="levelBtn" aria-label="Jump to level">
-        <option value="1">1 — Boot Sector</option>
-        <option value="2">2 — System Cache</option>
-        <option value="3">3 — Firewall</option>
-        <option value="4">4 — Memory Lane</option>
-        <option value="5">5 — Glitch Zone</option>
-        <option value="6">6 — Virus Vault</option>
-        <option value="7">7 — Recompiler</option>
-        <option value="8">8 — Encryption Chamber</option>
-        <option value="9">9 — Fragment Core</option>
-        <option value="10">10 — The Sentinel</option>
-      </select>
-      <button id="goLevel" class="btn">Go</button>
-    </div>
   </header>
 
   <!-- Game root -->
@@ -54,6 +38,23 @@
         <div class="panel" role="document">
           <h2>Paused</h2>
           <p>Press Esc / Space / Enter to resume</p>
+
+          <div id="pause-level-select" class="hud-panel">
+            <label for="pauseLevelBtn">Level:</label>
+            <select id="pauseLevelBtn" aria-label="Jump to level">
+              <option value="1">1 — Boot Sector</option>
+              <option value="2">2 — System Cache</option>
+              <option value="3">3 — Firewall</option>
+              <option value="4">4 — Memory Lane</option>
+              <option value="5">5 — Glitch Zone</option>
+              <option value="6">6 — Virus Vault</option>
+              <option value="7">7 — Recompiler</option>
+              <option value="8">8 — Encryption Chamber</option>
+              <option value="9">9 — Fragment Core</option>
+              <option value="10">10 — The Sentinel</option>
+            </select>
+            <button id="pauseGoLevel" class="btn">Go</button>
+          </div>
 
           <section class="settings">
             <h3>Settings</h3>

--- a/js/Game.js
+++ b/js/Game.js
@@ -52,9 +52,9 @@ export class Game {
     this.ui.onPauseContinue(() => this._continueFromPause());
     this.ui.onPauseRestart(()  => this.restartLevel());
 
-    // Level select control
-    document.getElementById('goLevel')?.addEventListener('click', () => {
-      const lvl = parseInt(document.getElementById('levelBtn').value, 10);
+    // Level select control (pause menu)
+    document.getElementById('pauseGoLevel')?.addEventListener('click', () => {
+      const lvl = parseInt(document.getElementById('pauseLevelBtn').value, 10);
       this.jumpToLevel(lvl);
     });
 

--- a/js/UI.js
+++ b/js/UI.js
@@ -96,7 +96,7 @@ export class UI {
   updateFPS(ts, ignoreDrops = false){
     const dt = ts - this._lastTs;
     this._lastTs = ts;
-    if (dt <= 0) return;
+    if (ignoreDrops || dt <= 0) return;
 
     const inst = 1000 / dt;
     this._fpsEMA = this._fpsEMA ? (this._alpha*inst + (1-this._alpha)*this._fpsEMA) : inst;

--- a/style.css
+++ b/style.css
@@ -22,7 +22,7 @@ body {
 /* HUD */
 .hud {
   display: grid;
-  grid-template-columns: repeat(5, minmax(120px, 1fr)) auto;
+  grid-template-columns: repeat(5, minmax(120px, 1fr));
   gap: var(--g);
   padding: 0.6rem 0.8rem;
   max-width: 100vw;
@@ -115,12 +115,11 @@ body {
 /* Overlays */
 .overlay {
   position: absolute; inset: 0;
-  display: grid; place-items: center;
+  display: none; place-items: center;
   background: rgba(0,0,0,.7); color: #eafff7;
-  z-index: 1000; opacity: 0; pointer-events: none;
-  transition: opacity .18s ease-out;
+  z-index: 1000; pointer-events: none;
 }
-.overlay.show { opacity: 1; pointer-events: auto; }
+.overlay.show { display: grid; pointer-events: auto; }
 .overlay .panel {
   background: rgba(5,12,18,.9);
   border: 2px solid #00ff87;
@@ -170,8 +169,7 @@ body {
 /* Auto low-effects under heavy load */
 .board.lowfx .brick { box-shadow: none !important; }
 
-/* Pause-mode: avoid any overlay transition work (keeps frames clean) */
-.game.paused .overlay { transition: none !important; }
+
 
 /* Themes (light touches) */
 .theme-crt .board { filter: contrast(1.03) saturate(0.9); }


### PR DESCRIPTION
## Summary
- Move level selection into the pause menu so players can switch stages mid-game
- Remove top-bar selector and simplify overlays to reduce rendering cost
- Skip FPS/drop calculations while paused for steadier 60fps

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e83ec2c08324a5102f1254ce5a5d