### PR TITLE
Add start menu with links to story and custom maps

### DIFF
--- a/custom-maps.html
+++ b/custom-maps.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>BREAKOUT.EXE - Custom Maps</title>
+  <link rel="preload" href="./style.css" as="style" />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <section id="tile-map-demo">
+    <canvas id="tileMapCanvas" width="320" height="120"></canvas>
+    <button id="nextMap" class="btn">Next Map</button>
+  </section>
+
+  <script type="module" src="./js/tilemap/demo.js"></script>
+</body>
+</html>

--- a/start.html
+++ b/start.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>BREAKOUT.EXE - Start Menu</title>
+  <link rel="preload" href="./style.css" as="style" />
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    .start-menu { display: grid; place-items: center; height: 100vh; text-align: center; }
+    .start-menu .options { display: flex; flex-direction: column; gap: 1rem; margin-top: 2rem; }
+  </style>
+</head>
+<body>
+  <main class="start-menu">
+    <h1>BREAKOUT.EXE</h1>
+    <div class="options">
+      <a href="index.html" class="btn">Story Mode</a>
+      <a href="custom-maps.html" class="btn">Map Editor</a>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple start menu linking to Story Mode and Map Editor
- provide a custom maps page using the existing tile map demo

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f0e08468832487765e37e7698a97