### PR TITLE
Track moving bricks separately for efficient updates

### DIFF
--- a/js/Game.js
+++ b/js/Game.js
@@ -33,6 +33,7 @@ export class Game {
     this.level = 1;
 
     this.bricks = [];
+    this.movingBricks = [];
     this.grid = new ColliderGrid();
     this._gridRebuildCooldown = 0;
 
@@ -126,11 +127,12 @@ export class Game {
     this.ball.update(stepMs, this.paddle);
 
     // Moving bricks + periodic grid rebuild when motion exists
-    let moving = false;
-    for (const b of this.bricks) {
-      if ((b.vx || b.vy) && b.alive) { moving = true; b.tick(stepMs, this); }
+    for (let i = this.movingBricks.length - 1; i >= 0; i--) {
+      const b = this.movingBricks[i];
+      if (!b.alive || (!b.vx && !b.vy)) { this.movingBricks.splice(i, 1); continue; }
+      b.tick(stepMs, this);
     }
-    if (moving) {
+    if (this.movingBricks.length) {
       this._gridRebuildCooldown -= stepMs;
       if (this._gridRebuildCooldown <= 0) {
         this.grid.build(this.bricks, this.width, this.height);
@@ -205,6 +207,7 @@ export class Game {
     // Bricks
     this.layerBricks.innerHTML = '';
     this.bricks = this.script.createBricks(this);
+    this.movingBricks = this.bricks.filter(b => b.vx || b.vy);
     this.grid.build(this.bricks, this.width, this.height);
     this._gridRebuildCooldown = 0;
 
@@ -241,6 +244,7 @@ export class Game {
     this.ui.updateLives(this.lives);
     this.layerBricks.innerHTML = '';
     this.bricks = this.script.createBricks(this);
+    this.movingBricks = this.bricks.filter(b => b.vx || b.vy);
     this.grid.build(this.bricks, this.width, this.height);
     this.ball.resetToPaddle(this.paddle);
     this.input.paused = false;

--- a/js/levels/Level08_EncryptionChamber.js
+++ b/js/levels/Level08_EncryptionChamber.js
@@ -39,6 +39,7 @@ export function EncryptionChamber() {
         game.layerBricks.appendChild(node);
         const b = new Brick(node, slot.x, slot.y, slot.w, slot.h, { type:'regrow' });
         game.bricks.push(b);
+        if (b.vx || b.vy) game.movingBricks.push(b);
         game.grid.build(game.bricks, game.width, game.height);
       }
     },

--- a/js/levels/Level10_Sentinel.js
+++ b/js/levels/Level10_Sentinel.js
@@ -39,6 +39,7 @@ export function TheSentinel() {
         const x = Math.max(0, Math.min(game.width - w, game._boss.x + i*(w+gap) - w/2));
         const b = new Brick(node, x, y, w, h, { hp:1 });
         game.bricks.push(b);
+        if (b.vx || b.vy) game.movingBricks.push(b);
       }
       game.grid.build(game.bricks, game.width, game.height);
     },


### PR DESCRIPTION
## Summary
- Add `movingBricks` array to Game for tracking bricks with velocity
- Update simulation to iterate over moving bricks and rebuild collider grid only when necessary
- Ensure level loading and dynamic brick spawns register moving bricks

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f7c1bbdc832481b55e42ec6f7861