### PR TITLE
Optimize collider grid queries

### DIFF
--- a/js/Game.js
+++ b/js/Game.js
@@ -94,6 +94,9 @@ export class Game {
 
   // ----- Simulation tick (fixed step) -----
   simulate(stepMs) {
+    // Advance grid query marker each frame to invalidate previous hits
+    this.grid.beginFrame();
+
     // Overlay state + paused class (lets CSS throttle transitions)
     if (this.input.paused && !this._pauseShown) {
       this._pauseShown = true;


### PR DESCRIPTION
## Summary
- Replace Set-based dedupe with `_queryId` marker scheme and reusable array
- Increment query marker each frame to avoid stale hits

## Testing
- `npm test` *(fails: Could not read package.json)*
- `go test ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f7c361e88324901fc6e3ff70e40e